### PR TITLE
Fixes the behavior of the `title_in_header`

### DIFF
--- a/inst/template/cleanrmd.html
+++ b/inst/template/cleanrmd.html
@@ -95,21 +95,25 @@ $include-before$
 $endfor$
 
 <main>
-$if(title-in-header)$<header>$else$$endif$
-$if(title)$
-<h1 id="title" class="toc-ignore">$title$</h1>
-$endif$
-$if(subtitle)$
-<h2 id="subtitle" class="toc-ignore">$subtitle$</h2>
-$endif$
-$if(date)$
-<p id="date">$date$</p>
-$endif$
-$if(author)$
-<p id="author">$for(author)$$author$$sep$, $endfor$</p>
+ 
+$if(title-in-header)$
+<header>
+  $if(title)$
+  <h1 id="title" class="toc-ignore">$title$</h1>
+  $endif$
+  $if(subtitle)$
+  <h2 id="subtitle" class="toc-ignore">$subtitle$</h2>
+  $endif$
+  $if(date)$
+  <p id="date">$date$</p>
+  $endif$
+  $if(author)$
+  <p id="author">$for(author)$$author$$sep$, $endfor$</p>
+  $endif$
+</header>
+$else$
 $endif$
 
-$if(title-in-header)$</header>$else$$endif$
 $if(toc)$$toc$$endif$
 
 $body$


### PR DESCRIPTION
After a lot of confusion, and not managing to get the `title_in_header` working, I realized that maybe the implementation is not correct. This tiny patch fixes the issue for me, and I can use the `title_in_header: false` and not get the title as a header in the HTML! 🙂